### PR TITLE
typo: or → of

### DIFF
--- a/specs/motion.md
+++ b/specs/motion.md
@@ -61,7 +61,7 @@ The Motion class should have properties for:
 
 <h1 id="standard-reuse">2. Standard reuse</h1>
 
-Few specifications exist for motions, and few legislatures publish motions in a machine-readable format. In many, the only specified or recorded motions are those with a single [vote event](specs/vote-event.html). However, a single motion may have multiple vote events; for example, a voice vote followed by a recorded vote. The [inventory or terms](/appendices/terms.html) shows little agreement between specifications.
+Few specifications exist for motions, and few legislatures publish motions in a machine-readable format. In many, the only specified or recorded motions are those with a single [vote event](specs/vote-event.html). However, a single motion may have multiple vote events; for example, a voice vote followed by a recorded vote. The [inventory of terms](/appendices/terms.html) shows little agreement between specifications.
 
 <h1 id="classes-and-properties">3. Classes and properties</h1>
 


### PR DESCRIPTION
"inventory or terms" → "inventory of terms"
