### PR TITLE
Add Person.pronouns property

### DIFF
--- a/schemas/person.json
+++ b/schemas/person.json
@@ -66,7 +66,10 @@
     },
     "pronouns": {
       "description": "Personal pronouns",
-      "type": ["array", "null"]
+      "type": ["array", "null"],
+      "items": {
+        "type": "string"
+      }
     },
     "birth_date": {
       "description": "A date of birth",

--- a/schemas/person.json
+++ b/schemas/person.json
@@ -64,6 +64,10 @@
       "description": "A gender",
       "type": ["string", "null"]
     },
+    "pronouns": {
+      "description": "Personal pronouns",
+      "type": ["string", "null"]
+    },
     "birth_date": {
       "description": "A date of birth",
       "type": ["string", "null"],

--- a/schemas/person.json
+++ b/schemas/person.json
@@ -66,7 +66,7 @@
     },
     "pronouns": {
       "description": "Personal pronouns",
-      "type": ["string", "null"]
+      "type": ["array", "null"]
     },
     "birth_date": {
       "description": "A date of birth",

--- a/specs/index.md
+++ b/specs/index.md
@@ -669,6 +669,7 @@ For political groups, the range of the `group` property will be an [organization
 
 <h1 id="history">7. Change history</h1>
 
+* 2022-11-10: Add a pronouns property to the Person class.
 * 2017-05-27: Allow time zones in time values.
 * 2017-02-20: Inherit `classification` from Event to VoteEvent.
 * 2015-05-05: Add time components to the date properties of the Membership class.

--- a/specs/person.md
+++ b/specs/person.md
@@ -42,7 +42,7 @@ The Person class should have properties for:
 
 1. pronouns
 
-    >Optional for a Person to determine personal pronouns to be used, e.g. "John Doe will be at <u>their</u> constituency office next week."
+    >Optional list of pronouns for a Person to determine personal pronouns to be used, e.g. "John Doe will be at <u>their</u> constituency office next week."
 
 1. date of birth
 

--- a/specs/person.md
+++ b/specs/person.md
@@ -38,40 +38,44 @@ The Person class should have properties for:
 
 1. gender
 
-    >To determine personal pronouns, e.g. "John Doe will be at <u>his</u> constituency office next week."
+    >Optional for a Person to most accurately describe their own gender. Values other than 'male' and 'female' may be used, but are not enumerated here. Not intended to capture the full variety of biological, social and sexual concepts associated with the word 'gender'.
 
-1. date of birth
+2. pronouns
+
+    >Optional for a Person to determine personal pronouns to be used, e.g. "John Doe will be at <u>their</u> constituency office next week."
+
+3. date of birth
 
     >To provide biographical detail, or to report a person's age.
 
-1. date of death
+4. date of death
 
     >To determine whether a person is alive or dead, e.g. in order to disable the deceased's contact form.
 
-1. [head shot](http://en.wikipedia.org/wiki/Head_shot)
+5. [head shot](http://en.wikipedia.org/wiki/Head_shot)
 
     >To identify the person visually.
 
-1. one-line biography
+6. one-line biography
 
     >To provide a brief biography.
 
-1. biography
+7. biography
 
     >To provide a long form biography.
 
-1. national identity
+8. national identity
 
     >Nine members of the [House of Peoples](http://en.wikipedia.org/wiki/House_of_Peoples_of_Bosnia_and_Herzegovina) shall comprise a quorum, provided that at least three Bosniak, three Croat, and three Serb delegates are present.
 
-1. the means of contacting the person
+9. the means of contacting the person
 
     >1 Main Street  
     Anytown, USA  
     555-555-0100  
     john@example.com
 
-1. external links
+10. external links
 
     >A representative's Wikipedia page or official website.
 

--- a/specs/person.md
+++ b/specs/person.md
@@ -38,11 +38,11 @@ The Person class should have properties for:
 
 1. gender
 
-    >Optional for a Person to most accurately describe their own gender. Values other than 'male' and 'female' may be used, but are not enumerated here. Not intended to capture the full variety of biological, social and sexual concepts associated with the word 'gender'.
+    >To measure the gender diversity of a group.
 
-1. pronouns
+1. personal pronouns
 
-    >Optional list of pronouns for a Person to determine personal pronouns to be used, e.g. "John Doe will be at <u>their</u> constituency office next week."
+    >To construct sentences containing personal pronouns, e.g. "John Doe will be at <u>their</u> constituency office next week."
 
 1. date of birth
 

--- a/specs/person.md
+++ b/specs/person.md
@@ -40,42 +40,42 @@ The Person class should have properties for:
 
     >Optional for a Person to most accurately describe their own gender. Values other than 'male' and 'female' may be used, but are not enumerated here. Not intended to capture the full variety of biological, social and sexual concepts associated with the word 'gender'.
 
-2. pronouns
+1. pronouns
 
     >Optional for a Person to determine personal pronouns to be used, e.g. "John Doe will be at <u>their</u> constituency office next week."
 
-3. date of birth
+1. date of birth
 
     >To provide biographical detail, or to report a person's age.
 
-4. date of death
+1. date of death
 
     >To determine whether a person is alive or dead, e.g. in order to disable the deceased's contact form.
 
-5. [head shot](http://en.wikipedia.org/wiki/Head_shot)
+1. [head shot](http://en.wikipedia.org/wiki/Head_shot)
 
     >To identify the person visually.
 
-6. one-line biography
+1. one-line biography
 
     >To provide a brief biography.
 
-7. biography
+1. biography
 
     >To provide a long form biography.
 
-8. national identity
+1. national identity
 
     >Nine members of the [House of Peoples](http://en.wikipedia.org/wiki/House_of_Peoples_of_Bosnia_and_Herzegovina) shall comprise a quorum, provided that at least three Bosniak, three Croat, and three Serb delegates are present.
 
-9. the means of contacting the person
+1. the means of contacting the person
 
     >1 Main Street  
     Anytown, USA  
     555-555-0100  
     john@example.com
 
-10. external links
+1. external links
 
     >A representative's Wikipedia page or official website.
 


### PR DESCRIPTION
- Don't use gender field to determine personal pronouns, use pronouns field instead.
- pronouns should be an array not a string
- avoid manual numbering for markdown list
- mention this is a list/array in the description
- feat: Person.pronouns is an array of strings
- docs: Update changelog

closes #129